### PR TITLE
Fixed level password serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `dash-rs` (spoken 'dashers') is an experimental library related to modelling, and more imporant _processing_ all data formats related to RobTop's 2013 game "Geometry Dash". The long-term goal is to have this crate replace `gdcf_model`, `gdcf_parse` and some parts of `gdrs` in GDCF.
 
-The project is a collaboration with mgostih, on whose idea the initial library design is based on and who continues to provide incredibly helpful insights into optimization, Geometry Dash and Rust.
+The project is a collaboration with [mgostIH](https://github.com/mgostIH), on whose idea the initial library design is based on and who continues to provide incredibly helpful insights into optimization, Geometry Dash and Rust.
 
 ## Goals
 

--- a/src/model/level/mod.rs
+++ b/src/model/level/mod.rs
@@ -299,13 +299,17 @@ impl Serialize for DecodedPassword {
         assert!(password[1..].len() == self.0.as_bytes().len(), "The level password size doesn't match.");
         password[1..].copy_from_slice(self.0.as_bytes());
 
+        // We need to do the xor **before** we get the base64 encoded data
+        util::cyclic_xor(&mut password, LEVEL_PASSWORD_XOR_KEY);
+
         let encoded = base64::encode_config_slice(&password, URL_SAFE, &mut base64_buffer);
 
         debug_assert!(encoded == 12);
 
-        util::cyclic_xor(&mut base64_buffer, LEVEL_PASSWORD_XOR_KEY);
-
+        
+        // serialize_bytes isn't yet implemented on our serializer, we could implement it such that the base64 encoding happens there.
         serializer.serialize_bytes(&base64_buffer)
+
     }
 }
 


### PR DESCRIPTION
The xor has to happen on the actual password data, not its base 64 encoding.