### PR TITLE
Forbid unsafe-code usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(
     const_err,
     illegal_floating_point_literal_pattern,


### PR DESCRIPTION
As mentioned in #2 and implemented in #6, we no longer use unsafe code and plan to not do so in the future