### PR TITLE
Eliminate Peekable in IndexedDeserializer

### DIFF
--- a/benches/level_processing_benchmark.rs
+++ b/benches/level_processing_benchmark.rs
@@ -40,7 +40,7 @@ pub fn decoding_ocular_miracle_benchmark(c: &mut Criterion) {
                     let mut decoder = GzDecoder::new(&decoded[..]);
 
                     decoder.read_to_string(&mut decompressed).unwrap();
-                }
+                },
                 Thunk::Processed(_) => unreachable!(),
             }
         })
@@ -60,7 +60,7 @@ pub fn decoding_spacial_rend_benchmark(c: &mut Criterion) {
                     let mut decoder = GzDecoder::new(&decoded[..]);
 
                     decoder.read_to_string(&mut decompressed).unwrap();
-                }
+                },
                 Thunk::Processed(_) => unreachable!(),
             }
         })

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -206,13 +206,14 @@ impl<'a> HasRobtopFormat<'a> for Level<'a, Option<u64>, u64> {
 
         let level_data = match internal.level_data {
             None => None,
-            Some(RefThunk::Unprocessed(level_string)) => Some(LevelData {
-                level_data: Thunk::Unprocessed(level_string),
-                password: internal.password.map(|pw| pw.0).unwrap_or(Password::NoCopy),
-                time_since_upload: Cow::Borrowed(internal.time_since_upload.unwrap_or("Unknown")),
-                time_since_update: Cow::Borrowed(internal.time_since_update.unwrap_or("Unknown")),
-                index_36: internal.index_36.map(Cow::Borrowed),
-            }),
+            Some(RefThunk::Unprocessed(level_string)) =>
+                Some(LevelData {
+                    level_data: Thunk::Unprocessed(level_string),
+                    password: internal.password.map(|pw| pw.0).unwrap_or(Password::NoCopy),
+                    time_since_upload: Cow::Borrowed(internal.time_since_upload.unwrap_or("Unknown")),
+                    time_since_update: Cow::Borrowed(internal.time_since_update.unwrap_or("Unknown")),
+                    index_36: internal.index_36.map(Cow::Borrowed),
+                }),
             _ => unreachable!(),
         };
 

--- a/src/model/level/mod.rs
+++ b/src/model/level/mod.rs
@@ -351,7 +351,7 @@ impl Password {
                 let password = decoded_str.parse().map_err(ProcessError::IntParse)?;
 
                 Password::PasswordCopy(password)
-            }
+            },
         })
     }
 }
@@ -367,7 +367,7 @@ impl Serialize for Internal<Password> {
             Password::PasswordCopy(pw) => {
                 // serialize_bytes does the base64 encode by itself
                 serializer.serialize_bytes(&robtop_encode_level_password(pw))
-            }
+            },
         }
     }
 }
@@ -715,7 +715,7 @@ impl<'a> ThunkContent<'a> for Objects {
                 let mut decoder = GzDecoder::new(&decoded[..]);
 
                 decoder.read_to_string(&mut decompressed).map_err(LevelProcessError::Compression)?;
-            }
+            },
             // There's no such thing as "zlib magic bytes", but the first byte stores some information about how the data is compressed.
             // '0x78' is the first byte for the compression method robtop used (note: this is only used for very old levels, as he switched
             // to gz for newer levels)
@@ -723,11 +723,11 @@ impl<'a> ThunkContent<'a> for Objects {
                 let mut decoder = ZlibDecoder::new(&decoded[..]);
 
                 decoder.read_to_string(&mut decompressed).map_err(LevelProcessError::Compression)?;
-            }
+            },
             _ => return Err(LevelProcessError::UnknownCompression),
         }
 
-        let mut iter = decompressed[..decompressed.len() - 1].split(';');
+        let mut iter = decompressed.split_terminator(';');
 
         let metadata_string = match iter.next() {
             Some(meta) => meta,

--- a/src/model/level/object/internal.rs
+++ b/src/model/level/object/internal.rs
@@ -37,22 +37,26 @@ impl<'a> HasRobtopFormat<'a> for LevelObject {
         let internal = InternalLevelObject::deserialize(&mut IndexedDeserializer::new(input, ",", true))?;
 
         let metadata = match internal.id {
-            ids::SLOW_PORTAL => ObjectData::SpeedPortal {
-                checked: internal.checked,
-                speed: Speed::Slow,
-            },
-            ids::NORMAL_PORTAL => ObjectData::SpeedPortal {
-                checked: internal.checked,
-                speed: Speed::Normal,
-            },
-            ids::FAST_PORTAL => ObjectData::SpeedPortal {
-                checked: internal.checked,
-                speed: Speed::Fast,
-            },
-            ids::VERY_FAST_PORTAL => ObjectData::SpeedPortal {
-                checked: internal.checked,
-                speed: Speed::VeryFast,
-            },
+            ids::SLOW_PORTAL =>
+                ObjectData::SpeedPortal {
+                    checked: internal.checked,
+                    speed: Speed::Slow,
+                },
+            ids::NORMAL_PORTAL =>
+                ObjectData::SpeedPortal {
+                    checked: internal.checked,
+                    speed: Speed::Normal,
+                },
+            ids::FAST_PORTAL =>
+                ObjectData::SpeedPortal {
+                    checked: internal.checked,
+                    speed: Speed::Fast,
+                },
+            ids::VERY_FAST_PORTAL =>
+                ObjectData::SpeedPortal {
+                    checked: internal.checked,
+                    speed: Speed::VeryFast,
+                },
             _ => ObjectData::Unknown,
         };
 
@@ -79,10 +83,10 @@ impl<'a> HasRobtopFormat<'a> for LevelObject {
         };
 
         match self.metadata {
-            ObjectData::None | ObjectData::Unknown => {}
+            ObjectData::None | ObjectData::Unknown => {},
             ObjectData::SpeedPortal { checked, .. } => {
                 internal.checked = checked;
-            }
+            },
         };
 
         internal.serialize(&mut IndexedSerializer::new(",", writer, true))

--- a/src/serde/ser/request.rs
+++ b/src/serde/ser/request.rs
@@ -344,7 +344,7 @@ impl<'ser, 'a, W: Write> Serializer for &'a mut ValueSerializer<'ser, W> {
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         if self.key.is_none() {
-            return Err(Error::Unsupported("Nested sequences"));
+            return Err(Error::Unsupported("Nested sequences"))
         }
 
         self.write_key()?;
@@ -382,7 +382,7 @@ impl<'ser, 'a, W: Write> Serializer for &'a mut ValueSerializer<'ser, W> {
 
     fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct, Self::Error> {
         if self.key.is_none() {
-            return Err(Error::Unsupported("struct inside sequence"));
+            return Err(Error::Unsupported("struct inside sequence"))
         }
 
         // If we inline a struct, that struct might not be the first field we serialize. However, we do not

--- a/src/serde/thunk.rs
+++ b/src/serde/thunk.rs
@@ -96,10 +96,11 @@ impl<'input, 'content, C: ThunkContent<'input>> Serialize for RefThunk<'input, '
     {
         match self {
             RefThunk::Unprocessed(unprocessed) => serializer.serialize_str(unprocessed),
-            RefThunk::Processed(ref processed) => match processed.as_unprocessed().map_err(serde::ser::Error::custom)? {
-                Cow::Borrowed(s) => serializer.serialize_str(s),
-                Cow::Owned(s) => s.serialize(serializer),
-            },
+            RefThunk::Processed(ref processed) =>
+                match processed.as_unprocessed().map_err(serde::ser::Error::custom)? {
+                    Cow::Borrowed(s) => serializer.serialize_str(s),
+                    Cow::Owned(s) => s.serialize(serializer),
+                },
         }
     }
 }
@@ -145,10 +146,11 @@ impl<'a, C: ThunkContent<'a>> Serialize for Internal<Thunk<'a, C>> {
     {
         match self.0 {
             Thunk::Unprocessed(unprocessed) => serializer.serialize_str(unprocessed),
-            Thunk::Processed(ref processed) => match processed.as_unprocessed().map_err(serde::ser::Error::custom)? {
-                Cow::Borrowed(s) => serializer.serialize_str(s),
-                Cow::Owned(s) => s.serialize(serializer),
-            },
+            Thunk::Processed(ref processed) =>
+                match processed.as_unprocessed().map_err(serde::ser::Error::custom)? {
+                    Cow::Borrowed(s) => serializer.serialize_str(s),
+                    Cow::Owned(s) => s.serialize(serializer),
+                },
         }
     }
 }

--- a/tests/serde_roundtrips.rs
+++ b/tests/serde_roundtrips.rs
@@ -9,7 +9,8 @@ use dash_rs::{
 };
 use std::borrow::Cow;
 
-const DARK_REALM_DATA: &str = "1:11774780:2:Dark \
+const DARK_REALM_DATA: &str =
+    "1:11774780:2:Dark \
      Realm:5:2:6:2073761:8:10:9:30:10:90786:12:0:13:20:14:10974:17:1:43:0:25::18:10:19:11994:42:0:45:0:3:\
      TXkgYmVzdCBsZXZlbCB5ZXQuIFZpZGVvIG9uIG15IFlvdVR1YmUuIEhhdmUgZnVuIGluIHRoaXMgZmFzdC1wYWNlZCBERU1PTiA-OikgdjIgRml4ZWQgc29tZSB0aGluZ3M=:\
      15:3:30:0:31:0:37:3:38:1:39:10:46:1:47:2:35:444085";


### PR DESCRIPTION
Peekable was used in two placed, once for `deserialize_option` to decide whether we are dealing with `None` or `Some(_)`, and then for error reporting, see also #16 

Instead of peeking, we now only keep track how far into the input string we have progressed already. For error handling, this means that after an error happens, we can just go _back_ in the input string to extract the field that caused the error, and since error reporting of obviously a cold code path, this is more efficient than keeping track of the value before parsing just in case there is an error.

For the `deserialize_option` case, we now just check if either we have reached EOF, or if following the current index into the input string is another delimiter (meaning there are two consecutive delimiters, aka a `None` value)