### PR TITLE
Parameterize Level based on presence of level data

### DIFF
--- a/benches/level_processing_benchmark.rs
+++ b/benches/level_processing_benchmark.rs
@@ -1,8 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use dash_rs::{model::level::Level, HasRobtopFormat, Thunk};
+use dash_rs::{
+    model::level::{Level, LevelData},
+    HasRobtopFormat, Thunk,
+};
 use flate2::read::GzDecoder;
 use std::{fs::read_to_string, io::Read};
-use dash_rs::model::level::LevelData;
 
 pub fn ocular_miracle_benchmark(c: &mut Criterion) {
     let response = read_to_string("./benches/data/62152040_ocular_miracle_gjdownload_response").unwrap();
@@ -21,7 +23,7 @@ pub fn spacial_rend_benchmark(c: &mut Criterion) {
 
     c.bench_function("parse spacial rend", |b| {
         b.iter(|| {
-            let mut level : Level<LevelData>= Level::from_robtop_str(&response).unwrap();
+            let mut level: Level<LevelData> = Level::from_robtop_str(&response).unwrap();
 
             level.level_data.level_data.process().unwrap();
         })

--- a/benches/level_processing_benchmark.rs
+++ b/benches/level_processing_benchmark.rs
@@ -2,15 +2,16 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use dash_rs::{model::level::Level, HasRobtopFormat, Thunk};
 use flate2::read::GzDecoder;
 use std::{fs::read_to_string, io::Read};
+use dash_rs::model::level::LevelData;
 
 pub fn ocular_miracle_benchmark(c: &mut Criterion) {
     let response = read_to_string("./benches/data/62152040_ocular_miracle_gjdownload_response").unwrap();
 
     c.bench_function("parse ocular machine", |b| {
         b.iter(|| {
-            let level = Level::from_robtop_str(&response).unwrap();
+            let mut level: Level<LevelData> = Level::from_robtop_str(&response).unwrap();
 
-            level.level_data.unwrap().level_data.process().unwrap();
+            level.level_data.level_data.process().unwrap();
         })
     });
 }
@@ -20,9 +21,9 @@ pub fn spacial_rend_benchmark(c: &mut Criterion) {
 
     c.bench_function("parse spacial rend", |b| {
         b.iter(|| {
-            let level = Level::from_robtop_str(&response).unwrap();
+            let mut level : Level<LevelData>= Level::from_robtop_str(&response).unwrap();
 
-            level.level_data.unwrap().level_data.process().unwrap();
+            level.level_data.level_data.process().unwrap();
         })
     });
 }
@@ -32,8 +33,8 @@ pub fn decoding_ocular_miracle_benchmark(c: &mut Criterion) {
 
     c.bench_function("decode ocular miracle", |b| {
         b.iter(|| {
-            let level = Level::from_robtop_str(&response).unwrap();
-            match level.level_data.unwrap().level_data {
+            let level: Level<LevelData> = Level::from_robtop_str(&response).unwrap();
+            match level.level_data.level_data {
                 Thunk::Unprocessed(unprocessed) => {
                     let decoded = base64::decode_config(unprocessed, base64::URL_SAFE).unwrap();
                     let mut decompressed = String::new();
@@ -52,8 +53,8 @@ pub fn decoding_spacial_rend_benchmark(c: &mut Criterion) {
 
     c.bench_function("decode spacial rend", |b| {
         b.iter(|| {
-            let level = Level::from_robtop_str(&response).unwrap();
-            match level.level_data.unwrap().level_data {
+            let level: Level<LevelData> = Level::from_robtop_str(&response).unwrap();
+            match level.level_data.level_data {
                 Thunk::Unprocessed(unprocessed) => {
                     let decoded = base64::decode_config(unprocessed, base64::URL_SAFE).unwrap();
                     let mut decompressed = String::new();

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -222,18 +222,13 @@ impl<'a> HasRobtopFormat<'a> for Level<'a> {
                 index: Some("29"),
                 value: None
             }),
-            (_, _, _, _, None) => return Err(DeError::Custom {
-                message: "Missing index_36".to_string(),
-                index: Some("36"),
-                value: None
-            }),
-            (Some(RefThunk::Unprocessed(level_string)), Some(Internal(password)), Some(upload), Some(update), Some(index_36)) =>
+            (Some(RefThunk::Unprocessed(level_string)), Some(Internal(password)), Some(upload), Some(update), index_36) =>
                 LevelData {
                     level_data: Thunk::Unprocessed(level_string),
                     password,
                     time_since_upload: Cow::Borrowed(upload),
                     time_since_update: Cow::Borrowed(update),
-                    index_36: Some(Cow::Borrowed(index_36),)
+                    index_36: index_36.map(Cow::Borrowed)
                 },
             _ => unreachable!(),
         };

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -201,34 +201,44 @@ impl<'a> HasRobtopFormat<'a> for Level<'a> {
     fn from_robtop_str(input: &'a str) -> Result<Self, DeError> {
         let internal = InternalLevel::deserialize(&mut IndexedDeserializer::new(input, ":", true))?;
 
-        let level_data = match (internal.level_data, internal.password, internal.time_since_update, internal.time_since_update, internal.index_36) {
-            (None, _, _, _, _) => return Err(DeError::Custom {
-                message: "Missing level data".to_string(),
-                index: Some("4"),
-                value: None
-            }),
-            (_, None, _, _, _) => return Err(DeError::Custom {
-                message: "Missing level password".to_string(),
-                index: Some("27"),
-                value: None
-            }),
-            (_, _,None, _, _) => return Err(DeError::Custom {
-                message: "Missing level upload timestamp".to_string(),
-                index: Some("28"),
-                value: None
-            }),
-            (_, _, _, None, _) => return Err(DeError::Custom {
-                message: "Missing level update timestamp".to_string(),
-                index: Some("29"),
-                value: None
-            }),
+        let level_data = match (
+            internal.level_data,
+            internal.password,
+            internal.time_since_update,
+            internal.time_since_update,
+            internal.index_36,
+        ) {
+            (None, ..) =>
+                return Err(DeError::Custom {
+                    message: "Missing level data".to_string(),
+                    index: Some("4"),
+                    value: None,
+                }),
+            (_, None, ..) =>
+                return Err(DeError::Custom {
+                    message: "Missing level password".to_string(),
+                    index: Some("27"),
+                    value: None,
+                }),
+            (_, _, None, ..) =>
+                return Err(DeError::Custom {
+                    message: "Missing level upload timestamp".to_string(),
+                    index: Some("28"),
+                    value: None,
+                }),
+            (_, _, _, None, _) =>
+                return Err(DeError::Custom {
+                    message: "Missing level update timestamp".to_string(),
+                    index: Some("29"),
+                    value: None,
+                }),
             (Some(RefThunk::Unprocessed(level_string)), Some(Internal(password)), Some(upload), Some(update), index_36) =>
                 LevelData {
                     level_data: Thunk::Unprocessed(level_string),
                     password,
                     time_since_upload: Cow::Borrowed(upload),
                     time_since_update: Cow::Borrowed(update),
-                    index_36: index_36.map(Cow::Borrowed)
+                    index_36: index_36.map(Cow::Borrowed),
                 },
             _ => unreachable!(),
         };
@@ -311,14 +321,13 @@ impl<'a> HasRobtopFormat<'a> for Level<'a> {
             level_data: Some(self.level_data.level_data.as_ref_thunk()),
             password: Some(Internal(self.level_data.password)),
             time_since_upload: Some(self.level_data.time_since_upload.borrow()),
-            time_since_update:  Some(self.level_data.time_since_update.borrow()),
+            time_since_update: Some(self.level_data.time_since_update.borrow()),
             index_36: self.level_data.index_36.as_ref().map(Borrow::borrow),
         };
 
         internal.serialize(&mut IndexedSerializer::new(":", writer, true))
     }
 }
-
 
 impl<'a> HasRobtopFormat<'a> for Level<'a, ()> {
     fn from_robtop_str(input: &'a str) -> Result<Self, DeError> {
@@ -402,7 +411,7 @@ impl<'a> HasRobtopFormat<'a> for Level<'a, ()> {
             level_data: None,
             password: None,
             time_since_upload: None,
-            time_since_update:  None,
+            time_since_update: None,
             index_36: None,
         };
 

--- a/src/model/level/mod.rs
+++ b/src/model/level/mod.rs
@@ -377,7 +377,7 @@ impl Display for Password {
     }
 }
 
-pub type ListedLevel<'a> = Level<'a, Option<NewgroundsSong<'a>>, Option<Creator<'a>>>;
+pub type ListedLevel<'a> = Level<'a, (), Option<NewgroundsSong<'a>>, Option<Creator<'a>>>;
 
 /// Struct representing levels as returned by the boomlings API.
 ///
@@ -413,7 +413,7 @@ pub type ListedLevel<'a> = Level<'a, Option<NewgroundsSong<'a>>, Option<Creator<
 /// `17`, `20`, `21`, `22`, `23`, `24`, `26`, `31`, `32`, `33`, `34`, `40`,
 /// `41`, `44`
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Level<'a, Song = Option<u64>, User = u64> {
+pub struct Level<'a, Data = LevelData<'a>, Song = Option<u64>, User = u64> {
     /// The level's unique level id
     ///
     /// ## GD Internals:
@@ -587,8 +587,7 @@ pub struct Level<'a, Song = Option<u64>, User = u64> {
     /// Additional data about this level that can be retrieved by downloading the level.
     ///
     /// This is [`None`] for levels retrieved via the "overview" endpoint `getGJLevels`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub level_data: Option<LevelData<'a>>,
+    pub level_data: Data,
 }
 
 /// Struct encapsulating the additional level data returned when actually downloading a level

--- a/src/model/level/mod.rs
+++ b/src/model/level/mod.rs
@@ -13,8 +13,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     model::{
+        creator::Creator,
         level::{metadata::LevelMetadata, object::LevelObject},
-        song::MainSong,
+        song::{MainSong, NewgroundsSong},
         GameVersion,
     },
     serde::{Base64Decoded, HasRobtopFormat, Internal, ProcessError, ThunkContent},
@@ -22,8 +23,6 @@ use crate::{
 };
 use flate2::Compression;
 use serde::de::Error;
-use crate::model::song::NewgroundsSong;
-use crate::model::creator::Creator;
 
 // use flate2::read::GzDecoder;
 // use std::io::Read;

--- a/src/response.rs
+++ b/src/response.rs
@@ -59,7 +59,6 @@ impl<'a> From<DeError<'a>> for ResponseError<'a> {
     }
 }
 
-// TODO: Type aliases, maybe? This is pretty ridiculous lul
 pub fn parse_get_gj_levels_response(response: &str) -> Result<Vec<ListedLevel>, ResponseError> {
     if response == "-1" {
         return Err(ResponseError::NotFound)
@@ -80,7 +79,7 @@ pub fn parse_get_gj_levels_response(response: &str) -> Result<Vec<ListedLevel>, 
     levels
         .split('|')
         .map(|fragment| {
-            let level = Level::from_robtop_str(fragment)?;
+            let level: Level<()> = Level::from_robtop_str(fragment)?;
             // Note: Cloning is cheap because none of the Thunks is evaluated, so we only have references lying
             // around.
             let creator = creators.iter().find(|creator| creator.user_id == level.creator).map(Clone::clone);

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,7 +8,7 @@ use crate::{
             profile::ProfileComment,
         },
         creator::Creator,
-        level::Level,
+        level::{Level, ListedLevel},
         song::NewgroundsSong,
         user::{profile::Profile, searched::SearchedUser},
     },
@@ -16,7 +16,6 @@ use crate::{
 };
 use serde::export::Formatter;
 use std::fmt::Display;
-use crate::model::level::ListedLevel;
 
 // Since NoneError is not stabilized, we cannot do `impl From<NoneError> for ResponseError<'_>`, so
 // this is the next best thing

--- a/tests/level_meta.rs
+++ b/tests/level_meta.rs
@@ -130,31 +130,10 @@ impl<S, U> helper::ThunkProcessor for Level<'_, (), S, U> {
 }
 
 save_load_roundtrip!(save_load_roundtrip_dark_realm, Level<()>, DARK_REALM);
-load_save_roundtrip!(
-    load_save_roundtrip_dark_realm,
-    Level<()>,
-    DARK_REALM_DATA,
-    DARK_REALM,
-    ":",
-    true
-);
+load_save_roundtrip!(load_save_roundtrip_dark_realm, Level<()>, DARK_REALM_DATA, DARK_REALM, ":", true);
 
 save_load_roundtrip!(save_load_roundtrip_demon_world, Level<()>, DEMON_WORLD);
-load_save_roundtrip!(
-    load_save_roundtrip_demon_world,
-    Level<()>,
-    DEMON_WORLD_DATA,
-    DEMON_WORLD,
-    ":",
-    true
-);
+load_save_roundtrip!(load_save_roundtrip_demon_world, Level<()>, DEMON_WORLD_DATA, DEMON_WORLD, ":", true);
 
 save_load_roundtrip!(save_load_roundtrip_fantasy, Level<()>, FANTASY);
-load_save_roundtrip!(
-    load_save_roundtrip_fantasy,
-    Level<()>,
-    FANTASY_DATA,
-    FANTASY,
-    ":",
-    true
-);
+load_save_roundtrip!(load_save_roundtrip_fantasy, Level<()>, FANTASY_DATA, FANTASY, ":", true);

--- a/tests/level_meta.rs
+++ b/tests/level_meta.rs
@@ -29,7 +29,7 @@ const FANTASY_DATA: &str = "1:63355989:2:Fantasy:5:2:6:15557115:8:10:9:40:10:935
                             37866:3:Q29sbGFiIHdpdGggQnJpbmRpa3osIHRoYW5rIHlvdSBmb3IgdGhpcyBsZXZlbCB1d3UsIEVOSk9ZISEg:15:3:30:63309629:31:\
                             0:37:2:38:1:39:7:46:1:47:2:35:771517";
 
-const DARK_REALM: Level<Option<u64>, u64> = Level {
+const DARK_REALM: Level<()> = Level {
     level_id: 11774780,
     name: Cow::Borrowed("Dark Realm"),
     description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
@@ -56,10 +56,10 @@ const DARK_REALM: Level<Option<u64>, u64> = Level {
     object_amount: None,
     index_46: Some(Cow::Borrowed("1")),
     index_47: Some(Cow::Borrowed("2")),
-    level_data: None,
+    level_data: (),
 };
 
-const DEMON_WORLD: Level<Option<u64>, u64> = Level {
+const DEMON_WORLD: Level<()> = Level {
     level_id: 72540,
     name: Cow::Borrowed("demon world"),
     description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed("happy new year!!")))),
@@ -88,10 +88,10 @@ const DEMON_WORLD: Level<Option<u64>, u64> = Level {
     object_amount: None,
     index_46: Some(Cow::Borrowed("1")),
     index_47: Some(Cow::Borrowed("2")),
-    level_data: None,
+    level_data: (),
 };
 
-const FANTASY: Level<Option<u64>, u64> = Level {
+const FANTASY: Level<()> = Level {
     level_id: 63355989,
     name: Cow::Borrowed("Fantasy"),
     description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
@@ -118,10 +118,10 @@ const FANTASY: Level<Option<u64>, u64> = Level {
     object_amount: Some(37866),
     index_46: Some(Cow::Borrowed("1")),
     index_47: Some(Cow::Borrowed("2")),
-    level_data: None,
+    level_data: (),
 };
 
-impl<S, U> helper::ThunkProcessor for Level<'_, S, U> {
+impl<S, U> helper::ThunkProcessor for Level<'_, (), S, U> {
     fn process_all_thunks(&mut self) {
         if let Some(ref mut hunk) = self.description {
             assert!(hunk.process().is_ok())
@@ -129,30 +129,30 @@ impl<S, U> helper::ThunkProcessor for Level<'_, S, U> {
     }
 }
 
-save_load_roundtrip!(save_load_roundtrip_dark_realm, Level<Option<u64>, u64>, DARK_REALM);
+save_load_roundtrip!(save_load_roundtrip_dark_realm, Level<()>, DARK_REALM);
 load_save_roundtrip!(
     load_save_roundtrip_dark_realm,
-    Level<Option<u64>, u64>,
+    Level<()>,
     DARK_REALM_DATA,
     DARK_REALM,
     ":",
     true
 );
 
-save_load_roundtrip!(save_load_roundtrip_demon_world, Level<Option<u64>, u64>, DEMON_WORLD);
+save_load_roundtrip!(save_load_roundtrip_demon_world, Level<()>, DEMON_WORLD);
 load_save_roundtrip!(
     load_save_roundtrip_demon_world,
-    Level<Option<u64>, u64>,
+    Level<()>,
     DEMON_WORLD_DATA,
     DEMON_WORLD,
     ":",
     true
 );
 
-save_load_roundtrip!(save_load_roundtrip_fantasy, Level<Option<u64>, u64>, FANTASY);
+save_load_roundtrip!(save_load_roundtrip_fantasy, Level<()>, FANTASY);
 load_save_roundtrip!(
     load_save_roundtrip_fantasy,
-    Level<Option<u64>, u64>,
+    Level<()>,
     FANTASY_DATA,
     FANTASY,
     ":",

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -18,7 +18,7 @@ const CREO_DUNE_DATA_TOO_MANY_FIELDS: &str = "1~|~771277~|~54~|~should be ignore
 
 const CREATOR_REGISTERED_DATA_TOO_MANY_FIELDS: &str = "4170784:Serponge:119741:34:fda:32:asd:3";
 
-const TIME_PRESSURE: Level<'static> = Level {
+const TIME_PRESSURE: Level = Level {
     level_id: 897837,
     name: Cow::Borrowed("time pressure"),
     description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -18,7 +18,7 @@ const CREO_DUNE_DATA_TOO_MANY_FIELDS: &str = "1~|~771277~|~54~|~should be ignore
 
 const CREATOR_REGISTERED_DATA_TOO_MANY_FIELDS: &str = "4170784:Serponge:119741:34:fda:32:asd:3";
 
-const TIME_PRESSURE: Level<'static, Option<u64>, u64> = Level {
+const TIME_PRESSURE: Level<'static> = Level {
     level_id: 897837,
     name: Cow::Borrowed("time pressure"),
     description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
@@ -49,24 +49,30 @@ const TIME_PRESSURE: Level<'static, Option<u64>, u64> = Level {
     object_amount: None,
     index_46: None,
     index_47: None,
-    level_data: Some(LevelData {
+    level_data: LevelData {
         level_data: Thunk::Unprocessed("REMOVED"),
         password: Password::PasswordCopy(3101),
         time_since_upload: Cow::Borrowed("5 years"),
         time_since_update: Cow::Borrowed("5 years"),
         index_36: None,
-    }),
+    },
 };
 
-impl<S, U> helper::ThunkProcessor for Level<'_, S, U> {
+impl<S, U> helper::ThunkProcessor for Level<'_, LevelData<'_>, S, U> {
     fn process_all_thunks(&mut self) {
         if let Some(ref mut hunk) = self.description {
             assert!(hunk.process().is_ok())
         }
-        assert!(self.level_data.is_some());
-        let data = self.level_data.as_mut().unwrap();
-        let objects = data.level_data.process();
+        let objects = self.level_data.level_data.process();
         assert!(objects.is_ok(), "{:?}", objects.unwrap_err());
+    }
+}
+
+impl<S, U> helper::ThunkProcessor for Level<'_, (), S, U> {
+    fn process_all_thunks(&mut self) {
+        if let Some(ref mut hunk) = self.description {
+            assert!(hunk.process().is_ok())
+        }
     }
 }
 
@@ -82,16 +88,16 @@ fn deserialize_too_many_fields() {
 fn deserialize_level() {
     init_log();
 
-    let mut level = helper::load_processed::<Level<Option<u64>, u64>>(include_str!("data/11774780_dark_realm_gjdownload_response"));
+    let mut level = helper::load_processed::<Level>(include_str!("data/11774780_dark_realm_gjdownload_response"));
 }
 
 #[test]
 fn deserialize_level2() {
     init_log();
 
-    let mut level = helper::load_processed::<Level<Option<u64>, u64>>(include_str!("data/897837_time_pressure_gjdownload_response"));
+    let mut level = helper::load_processed::<Level>(include_str!("data/897837_time_pressure_gjdownload_response"));
 
-    level.level_data.as_mut().unwrap().level_data = Thunk::Unprocessed("REMOVED");
+    level.level_data.level_data = Thunk::Unprocessed("REMOVED");
 
     assert_eq!(level, TIME_PRESSURE);
 }


### PR DESCRIPTION
This PR adds a new type parameter to `Level` which describes what kind of level data is present. Right now the options are `()`, indicating that no level data was downloaded (the Level was part of a `getGJLevels` response) and `LevelData<'_>`, indicating that the entire level data exists (the Level was part of a `downloadGJLevel` response). 

This allows some more fine-grained error reporting in the deserialization impl and also decreases the "nesting" of the actual level data (one layer of `Option<_>` is removed)