### PR TITLE
Improvements to Thunk handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ percent-encoding = "2.1.0"
 itoa = "0.4.4"
 dtoa = "0.4.4"
 flate2 = {version = "1.0.14", features = ["zlib"], default-features=false}
+variant_partial_eq = { git = "https://github.com/stadust/variant-partial-eq" }
 
 [dev-dependencies]
 # benchmark

--- a/benches/level_processing_benchmark.rs
+++ b/benches/level_processing_benchmark.rs
@@ -38,7 +38,7 @@ pub fn decoding_ocular_miracle_benchmark(c: &mut Criterion) {
             let level: Level<LevelData> = Level::from_robtop_str(&response).unwrap();
             match level.level_data.level_data {
                 Thunk::Unprocessed(unprocessed) => {
-                    let decoded = base64::decode_config(unprocessed, base64::URL_SAFE).unwrap();
+                    let decoded = base64::decode_config(&*unprocessed, base64::URL_SAFE).unwrap();
                     let mut decompressed = String::new();
                     let mut decoder = GzDecoder::new(&decoded[..]);
 
@@ -58,7 +58,7 @@ pub fn decoding_spacial_rend_benchmark(c: &mut Criterion) {
             let level: Level<LevelData> = Level::from_robtop_str(&response).unwrap();
             match level.level_data.level_data {
                 Thunk::Unprocessed(unprocessed) => {
-                    let decoded = base64::decode_config(unprocessed, base64::URL_SAFE).unwrap();
+                    let decoded = base64::decode_config(&*unprocessed, base64::URL_SAFE).unwrap();
                     let mut decompressed = String::new();
                     let mut decoder = GzDecoder::new(&decoded[..]);
 

--- a/build.rs
+++ b/build.rs
@@ -40,8 +40,7 @@ fn write_preamble<W: Write>(f: &mut W) -> std::io::Result<()> {
     writeln!(f, "use crate::{{")?;
     writeln!(
         f,
-        "serde::{{DeError, HasRobtopFormat, IndexedDeserializer, IndexedSerializer, PercentDecoded, SerError, Thunk, \
-         Base64Decoded}},"
+        "serde::{{DeError, HasRobtopFormat, IndexedDeserializer, IndexedSerializer, SerError, Thunk}},"
     )?;
     writeln!(f, "}};")?;
     writeln!(f, "use serde::{{Deserialize, Serialize, ser::Error as _}};")?;

--- a/build.rs
+++ b/build.rs
@@ -229,9 +229,11 @@ impl Index {
 
     pub fn generate_binding<W: Write>(&self, f: &mut W, field_name: &str) -> std::io::Result<()> {
         // needed for lifetime reasons
-        if self.thunk && self.optional {
+        if self.thunk { if self.optional {
             writeln!(f, "let index_{} = self.{}.as_ref().map(|t| t.as_unprocessed().map_err(SerError::custom)).transpose()?;", self.value, field_name)?;
-        }
+        }else {
+            writeln!(f, "let index_{} = &*self.{}.as_unprocessed().map_err(SerError::custom)?;", self.value, field_name)?;
+        }}
 
         Ok(())
     }
@@ -243,7 +245,7 @@ impl Index {
             if self.optional {
                 write!(f, "index_{}.as_deref()", self.value)?;
             } else {
-                write!(f, "&*self.{}.as_unprocessed().map_err(SerError::custom)?", field_name)?;
+                write!(f, "index_{}", self.value)?;
             }
         } else {
             match &self.r#type[..] {

--- a/build.rs
+++ b/build.rs
@@ -198,13 +198,13 @@ impl Index {
             if self.optional {
                 write!(
                     f,
-                    "internal.index_{}.map(Thunk::Unprocessed)",
+                    "internal.index_{}.map(Cow::Borrowed).map(Thunk::Unprocessed)",
                     self.value
                 )?;
             } else {
                 write!(
                     f,
-                    "Thunk::Unprocessed(internal.index_{})",
+                    "Thunk::Unprocessed(Cow::Borrowed(internal.index_{}))",
                     self.value
                 )?;
             }

--- a/descriptions/level.yml
+++ b/descriptions/level.yml
@@ -157,8 +157,8 @@ special_fields:
     }
   level_data: |
     LevelData {
-      level_data: Thunk::Unprocessed(internal.index_4),
-      password: Thunk::Unprocessed(internal.index_27),
+      level_data: Thunk::Unprocessed(Cow::Borrowed(internal.index_4)),
+      password: Thunk::Unprocessed(Cow::Borrowed(internal.index_27)),
       time_since_upload: Cow::Borrowed(internal.index_28),
       time_since_update: Cow::Borrowed(internal.index_29),
       index_36: internal.index_36.map(Cow::Borrowed)

--- a/descriptions/level.yml
+++ b/descriptions/level.yml
@@ -122,9 +122,10 @@ indices:
     compute: |
       &*self.level_data.level_data.as_unprocessed().map_err(SerError::custom)?
   - value: 27
-    type: Internal<Password>
+    type: Password
+    thunk: true
     compute: |
-      Internal(self.level_data.password)
+      &*self.level_data.password.as_unprocessed().map_err(SerError::custom)?
   - value: 28
     type: '&''src str'
     compute: |
@@ -157,7 +158,7 @@ special_fields:
   level_data: |
     LevelData {
       level_data: Thunk::Unprocessed(internal.index_4),
-      password: internal.index_27.0,
+      password: Thunk::Unprocessed(internal.index_27),
       time_since_upload: Cow::Borrowed(internal.index_28),
       time_since_update: Cow::Borrowed(internal.index_29),
       index_36: internal.index_36.map(Cow::Borrowed)

--- a/descriptions/level.yml
+++ b/descriptions/level.yml
@@ -117,9 +117,10 @@ indices:
     type: 'Option<&''src str>'
     maps_to: index_47
   - value: 4
-    type: RefThunk<'src, 'bor, Objects>
+    type: Objects
+    thunk: true
     compute: |
-      self.level_data.level_data.as_ref_thunk()
+      &*self.level_data.level_data.as_unprocessed().map_err(SerError::custom)?
   - value: 27
     type: Internal<Password>
     compute: |
@@ -155,10 +156,7 @@ special_fields:
     }
   level_data: |
     LevelData {
-      level_data: match internal.index_4 {
-        RefThunk::Unprocessed(unproc) => Thunk::Unprocessed(unproc),
-        _ => unreachable!(),
-      },
+      level_data: Thunk::Unprocessed(internal.index_4),
       password: internal.index_27.0,
       time_since_upload: Cow::Borrowed(internal.index_28),
       time_since_update: Cow::Borrowed(internal.index_29),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,4 @@
 #![forbid(unsafe_code)]
-#![deny(
-    const_err,
-    illegal_floating_point_literal_pattern,
-    late_bound_lifetime_arguments,
-    non_camel_case_types,
-    non_shorthand_field_patterns,
-    non_snake_case,
-    bare_trait_objects,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    unused_extern_crates,
-    stable_features,
-    unknown_lints,
-    unused_features,
-    unreachable_code,
-    unreachable_patterns,
-    unused_allocation,
-    unused_attributes,
-    unused_must_use,
-    unused_mut,
-    while_true,
-    unused_imports,
-    unconditional_recursion,
-    unknown_lints,
-    unused_parens,
-    non_upper_case_globals,
-    path_statements,
-    patterns_in_fns_without_body,
-    renamed_and_removed_lints,
-    type_alias_bounds
-)]
 
 pub mod model;
 pub mod request;
@@ -37,4 +6,4 @@ pub mod response;
 pub(crate) mod serde;
 pub mod util;
 
-pub use crate::serde::{Base64Decoded, DeError, HasRobtopFormat, PercentDecoded, ProcessError, SerError, Thunk, ThunkContent};
+pub use crate::serde::{Base64Decoded, DeError, HasRobtopFormat, PercentDecoded, ProcessError, SerError, ThunkProcessor, Thunk};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,4 @@ pub mod response;
 pub(crate) mod serde;
 pub mod util;
 
-pub use crate::serde::{Base64Decoded, DeError, HasRobtopFormat, PercentDecoded, ProcessError, SerError, ThunkProcessor, Thunk};
+pub use crate::serde::{DeError, HasRobtopFormat, ProcessError, SerError, ThunkProcessor, Thunk};

--- a/src/model/comment/level.rs
+++ b/src/model/comment/level.rs
@@ -2,13 +2,14 @@ use std::borrow::Cow;
 // use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
+use variant_partial_eq::VariantPartialEq;
 
 use crate::{
     model::user::{Color, IconType, ModLevel},
-    Base64Decoded, Thunk,
 };
+use crate::serde::{Base64Decoder, Thunk};
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, VariantPartialEq, Clone, Deserialize, Serialize)]
 pub struct LevelComment<'a> {
     /// Information about the user that made this [`LevelComment`]. Is generally a [`CommentUser`]
     /// object
@@ -19,7 +20,8 @@ pub struct LevelComment<'a> {
     /// ## GD Internals
     /// This value is provided at index `2` and is base64 encoded
     #[serde(borrow)]
-    pub content: Option<Thunk<'a, Base64Decoded<'a>>>,
+    #[variant_compare = "crate::util::option_variant_eq"]
+    pub content: Option<Thunk<'a, Base64Decoder>>,
 
     /// The unique user id of the player who made this [`LevelComment`]
     ///

--- a/src/model/comment/profile.rs
+++ b/src/model/comment/profile.rs
@@ -1,15 +1,17 @@
-use crate::{Base64Decoded, Thunk};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use crate::serde::{Base64Decoder, Thunk};
+use variant_partial_eq::VariantPartialEq;
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Eq, VariantPartialEq, Clone)]
 pub struct ProfileComment<'a> {
     /// The actual content of the [`ProfileComment`] made.
     ///
     /// ## GD Internals
     /// This value is provided at index `2` and base64 encoded
     #[serde(borrow)]
-    pub content: Option<Thunk<'a, Base64Decoded<'a>>>,
+    #[variant_compare = "crate::util::option_variant_eq"]
+    pub content: Option<Thunk<'a, Base64Decoder>>,
 
     /// The amount of likes this [`ProfileComment`] has received
     ///

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -5,7 +5,7 @@ use crate::{
         song::MainSong,
         GameVersion,
     },
-    serde::{Base64Decoded, IndexedDeserializer, IndexedSerializer},
+    serde::{IndexedDeserializer, IndexedSerializer},
     DeError, HasRobtopFormat, SerError,
 };
 use serde::{Deserialize, Serialize};

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -5,7 +5,7 @@ use crate::{
         song::MainSong,
         GameVersion,
     },
-    serde::{Base64Decoded, IndexedDeserializer, IndexedSerializer, Internal, RefThunk},
+    serde::{Base64Decoded, IndexedDeserializer, IndexedSerializer, Internal},
     DeError, HasRobtopFormat, SerError, Thunk,
 };
 use serde::{Deserialize, Serialize};

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -6,7 +6,7 @@ use crate::{
         GameVersion,
     },
     serde::{Base64Decoded, IndexedDeserializer, IndexedSerializer},
-    DeError, HasRobtopFormat, SerError, Thunk,
+    DeError, HasRobtopFormat, SerError,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/model/level/internal.rs
+++ b/src/model/level/internal.rs
@@ -5,7 +5,7 @@ use crate::{
         song::MainSong,
         GameVersion,
     },
-    serde::{Base64Decoded, IndexedDeserializer, IndexedSerializer, Internal},
+    serde::{Base64Decoded, IndexedDeserializer, IndexedSerializer},
     DeError, HasRobtopFormat, SerError, Thunk,
 };
 use serde::{Deserialize, Serialize};

--- a/src/model/level/mod.rs
+++ b/src/model/level/mod.rs
@@ -369,8 +369,8 @@ impl ThunkProcessor for Password {
     type Error = ProcessError;
     type Output<'a> = Password;
 
-    fn from_unprocessed<'a>(unprocessed: &'a str) -> Result<Self, Self::Error> {
-        Password::from_robtop(unprocessed)
+    fn from_unprocessed<'a>(unprocessed: Cow<'a, str>) -> Result<Self, Self::Error> {
+        Password::from_robtop(&*unprocessed)
     }
 
     fn as_unprocessed<'a, 'b>(processed: &'b Self::Output<'a>) -> Result<Cow<'b, str>, Self::Error> {
@@ -693,10 +693,10 @@ impl ThunkProcessor for Objects {
     type Error = LevelProcessError;
     type Output<'a> = Objects;
 
-    fn from_unprocessed(unprocessed: &str) -> Result<Self, LevelProcessError> {
+    fn from_unprocessed(unprocessed: Cow<str>) -> Result<Self, LevelProcessError> {
         // Doing the entire base64 in one go is actually faster than using base64::read::DecoderReader and
         // having the two readers go back and forth.
-        let decoded = base64::decode_config(unprocessed, base64::URL_SAFE).map_err(LevelProcessError::Base64)?;
+        let decoded = base64::decode_config(&*unprocessed, base64::URL_SAFE).map_err(LevelProcessError::Base64)?;
 
         // Here's the deal: Robtop decompresses all levels by calling the zlib function 'inflateInit2_' with
         // the second argument set to 47. This basically tells zlib "this data might be compressed using

--- a/src/model/song.rs
+++ b/src/model/song.rs
@@ -1,9 +1,10 @@
-use crate::serde::{PercentDecoded, ProcessError, Thunk};
+use crate::serde::{PercentDecoded, PercentDecoder, ProcessError, Thunk};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     fmt::{Display, Formatter},
 };
+use variant_partial_eq::VariantPartialEq;
 
 mod internal {
     use crate::model::song::NewgroundsSong;
@@ -19,7 +20,7 @@ mod internal {
 ///
 /// ### Unused indices:
 /// The following indices aren't used by the Geometry Dash servers: `9`
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, VariantPartialEq, Serialize, Deserialize, Clone)]
 pub struct NewgroundsSong<'a> {
     /// The newgrounds id of this [`NewgroundsSong`]
     ///
@@ -66,7 +67,7 @@ pub struct NewgroundsSong<'a> {
     /// ## GD Internals
     /// This value is provided at index `10`, and is percent encoded.
     #[serde(borrow)]
-    pub link: Thunk<'a, PercentDecoded<'a>>,
+    pub link: Thunk<'a, PercentDecoder>,
 }
 
 impl<'a> NewgroundsSong<'a> {

--- a/src/model/song.rs
+++ b/src/model/song.rs
@@ -1,4 +1,4 @@
-use crate::serde::{PercentDecoded, PercentDecoder, ProcessError, Thunk};
+use crate::serde::{PercentDecoder, ProcessError, Thunk};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -81,7 +81,7 @@ impl<'a> NewgroundsSong<'a> {
             index_6: self.index_6.map(|cow| Cow::Owned(cow.into_owned())),
             index_7: self.index_7.map(|cow| Cow::Owned(cow.into_owned())),
             index_8: Cow::Owned(self.index_8.into_owned()),
-            link: Thunk::Processed(PercentDecoded(Cow::Owned(self.link.into_processed()?.0.into_owned()))),
+            link: Thunk::Processed(Cow::Owned(self.link.into_processed()?.into_owned())),
         })
     }
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -5,7 +5,6 @@ mod thunk;
 pub use de::{error::Error as DeError, indexed::IndexedDeserializer};
 pub use ser::{error::Error as SerError, indexed::IndexedSerializer, request::RequestSerializer};
 pub use thunk::{Base64Decoded, PercentDecoded, ProcessError, Thunk, ThunkContent};
-pub(crate) use thunk::{Internal};
 
 use std::io::Write;
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -5,7 +5,7 @@ mod thunk;
 pub use de::{error::Error as DeError, indexed::IndexedDeserializer};
 pub use ser::{error::Error as SerError, indexed::IndexedSerializer, request::RequestSerializer};
 pub use thunk::{Base64Decoded, PercentDecoded, ProcessError, Thunk, ThunkContent};
-pub(crate) use thunk::{Internal, RefThunk};
+pub(crate) use thunk::{Internal};
 
 use std::io::Write;
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -4,7 +4,7 @@ mod thunk;
 
 pub use de::{error::Error as DeError, indexed::IndexedDeserializer};
 pub use ser::{error::Error as SerError, indexed::IndexedSerializer, request::RequestSerializer};
-pub use thunk::{Base64Decoded, PercentDecoded, ProcessError, ThunkProcessor, Thunk, Base64Decoder, PercentDecoder};
+pub use thunk::{ProcessError, ThunkProcessor, Thunk, Base64Decoder, PercentDecoder};
 
 use std::io::Write;
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -4,7 +4,7 @@ mod thunk;
 
 pub use de::{error::Error as DeError, indexed::IndexedDeserializer};
 pub use ser::{error::Error as SerError, indexed::IndexedSerializer, request::RequestSerializer};
-pub use thunk::{Base64Decoded, PercentDecoded, ProcessError, Thunk, ThunkContent};
+pub use thunk::{Base64Decoded, PercentDecoded, ProcessError, ThunkProcessor, Thunk, Base64Decoder, PercentDecoder};
 
 use std::io::Write;
 

--- a/src/serde/thunk.rs
+++ b/src/serde/thunk.rs
@@ -99,14 +99,6 @@ pub trait ThunkContent<'a>: Sized {
     fn as_unprocessed(&self) -> Result<Cow<str>, Self::Error>;
 }
 
-// effectively pub(crate) since it's not reexported in lib.rs
-/// Marker type used to differentiate how [`Thunk`]s should serialize.
-///
-/// A `Internal<Thunk<C>>` should serialize its contents to RobTop's data format, while a `Thunk` in
-/// general should serialize to a sane format.
-#[derive(Debug)]
-pub struct Internal<I>(pub(crate) I);
-
 impl<'a, C: ThunkContent<'a>> Thunk<'a, C> {
     /// If this is a [`Thunk::Unprocessed`] variant, calls [`ThunkContent::from_unprocessed`] and
     /// returns [`Thunk::Processed`]. Simply returns `self` if this is a [`Thunk::Processed`]

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,16 @@ where
     encoded.iter_mut().zip(key.as_ref().iter().cycle()).for_each(|(d, k)| *d ^= k);
 }
 
+pub fn option_variant_eq<A, B>(a: &Option<A>, b: &Option<B>) -> bool
+    where A: PartialEq<B>
+{
+    match (a, b) {
+        (Some(a), Some(b)) => a == b,
+        (None, None) => true,
+        _ => false
+    }
+}
+
 pub(crate) mod default_to_none {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/tests/comment.rs
+++ b/tests/comment.rs
@@ -1,13 +1,10 @@
-use dash_rs::{
-    model::{
-        comment::{
-            level::{CommentUser, LevelComment},
-            profile::ProfileComment,
-        },
-        user::{Color, IconType, ModLevel},
+use dash_rs::{model::{
+    comment::{
+        level::{CommentUser, LevelComment},
+        profile::ProfileComment,
     },
-    Base64Decoded, Thunk,
-};
+    user::{Color, IconType, ModLevel},
+}, Base64Decoded, Thunk};
 use std::borrow::Cow;
 
 #[macro_use]

--- a/tests/comment.rs
+++ b/tests/comment.rs
@@ -4,7 +4,7 @@ use dash_rs::{model::{
         profile::ProfileComment,
     },
     user::{Color, IconType, ModLevel},
-}, Base64Decoded, Thunk};
+}, Thunk};
 use std::borrow::Cow;
 
 #[macro_use]
@@ -20,9 +20,9 @@ const COMMENT_USER_DATA: &str = "1~Pauze~9~58~10~18~11~16~14~0~15~2~16~1705254";
 
 const LEVEL_COMMENT1: LevelComment = LevelComment {
     user: None,
-    content: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    content: Some(Thunk::Processed(Cow::Borrowed(
         "Special thanks to Hado, Cinci, Synactive, Cool, Prism, Subwoofer, and Hado for playtesting.",
-    )))),
+    ))),
     user_id: 7226087,
     likes: 104,
     comment_id: 258976,
@@ -35,7 +35,7 @@ const LEVEL_COMMENT1: LevelComment = LevelComment {
 
 const LEVEL_COMMENT2: LevelComment = LevelComment {
     user: None,
-    content: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed("Guru.")))),
+    content: Some(Thunk::Processed(Cow::Borrowed("Guru."))),
     user_id: 2723387,
     likes: 63,
     comment_id: 260007,
@@ -48,9 +48,9 @@ const LEVEL_COMMENT2: LevelComment = LevelComment {
 
 const LEVEL_COMMENT3: LevelComment = LevelComment {
     user: None,
-    content: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    content: Some(Thunk::Processed(Cow::Borrowed(
         "Lets make august 10th Pauze's international day",
-    )))),
+    ))),
     user_id: 7178197,
     likes: 58,
     comment_id: 259333,
@@ -105,9 +105,9 @@ const PROFILE_COMMENT_DATA: &str =
     "2~QSB3aW5kb3cgdG8gdGhlIHBhc3QsIGEgZ2xpbXBzZSBvZiB0aGUgZnV0dXJlLCBBbiBPZGUgdG8gVGltZS4=~4~432~9~6 days~6~1922667";
 
 const PROFILE_COMMENT: ProfileComment = ProfileComment {
-    content: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    content: Some(Thunk::Processed(Cow::Borrowed(
         "A window to the past, a glimpse of the future, An Ode to Time.",
-    )))),
+    ))),
     likes: 432,
     comment_id: 1922667,
     time_since_post: Cow::Borrowed("6 days"),

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -51,6 +51,7 @@ macro_rules! save_load_roundtrip {
         #[test]
         pub fn $name() {
             use helper::*;
+            use dash_rs::HasRobtopFormat;
 
             let _ = env_logger::builder().is_test(true).try_init();
 

--- a/tests/level_meta.rs
+++ b/tests/level_meta.rs
@@ -6,7 +6,7 @@ use dash_rs::{
         song::MainSong,
         GameVersion,
     },
-    Base64Decoded, Thunk,
+    Thunk,
 };
 
 #[macro_use]
@@ -35,9 +35,9 @@ const DUELO_MAETSTRO_DATA: &str = "1:23298409:2:Duelo Maestro:5:8:6:1295392:8:10
 const DARK_REALM: Level<()> = Level {
     level_id: 11774780,
     name: Cow::Borrowed("Dark Realm"),
-    description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    description: Some(Thunk::Processed(Cow::Borrowed(
         "My best level yet. Video on my YouTube. Have fun in this fast-paced DEMON >:) v2 Fixed some things",
-    )))),
+    ))),
     version: 2,
     creator: 2073761,
     difficulty: LevelRating::Demon(DemonRating::Hard),
@@ -64,7 +64,7 @@ const DARK_REALM: Level<()> = Level {
 const DEMON_WORLD: Level<()> = Level {
     level_id: 72540,
     name: Cow::Borrowed("demon world"),
-    description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed("happy new year!!")))),
+    description: Some(Thunk::Processed(Cow::Borrowed("happy new year!!"))),
     version: 7,
     creator: 37573,
     difficulty: LevelRating::Demon(DemonRating::Hard),
@@ -95,9 +95,9 @@ const DEMON_WORLD: Level<()> = Level {
 const FANTASY: Level<()> = Level {
     level_id: 63355989,
     name: Cow::Borrowed("Fantasy"),
-    description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    description: Some(Thunk::Processed(Cow::Borrowed(
         "Collab with Brindikz, thank you for this level uwu, ENJOY!! ",
-    )))),
+    ))),
     version: 2,
     creator: 15557115,
     difficulty: LevelRating::Harder,
@@ -124,10 +124,10 @@ const FANTASY: Level<()> = Level {
 const DUELO_MAESTRO: Level<()> = Level {
     level_id: 23298409,
     name: Cow::Borrowed("Duelo Maestro"),
-    description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    description: Some(Thunk::Processed(Cow::Borrowed(
         "El duelo de tus dos manos o de dos verdaderos maestros. A veces puedes morir inexplicablemente en la primera bola, porfa \
          reinicien el nivel.",
-    )))),
+    ))),
     version: 8,
     creator: 1295392,
     difficulty: LevelRating::Demon(DemonRating::Insane),

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -49,7 +49,7 @@ const TIME_PRESSURE: Level = Level {
     index_46: None,
     index_47: None,
     level_data: LevelData {
-        level_data: Thunk::Unprocessed("REMOVED"),
+        level_data: Thunk::Unprocessed(Cow::Borrowed("REMOVED")),
         password: Thunk::Processed(Password::PasswordCopy(3101)),
         time_since_upload: Cow::Borrowed("5 years"),
         time_since_update: Cow::Borrowed("5 years"),
@@ -98,7 +98,7 @@ fn deserialize_level2() {
 
     let mut level = helper::load_processed::<Level>(include_str!("data/897837_time_pressure_gjdownload_response"));
 
-    level.level_data.level_data = Thunk::Unprocessed("REMOVED");
+    level.level_data.level_data = Thunk::Unprocessed(Cow::Borrowed("REMOVED"));
 
     assert_eq!(level, TIME_PRESSURE);
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -5,7 +5,7 @@ use dash_rs::{
         song::{MainSong, NewgroundsSong},
         GameVersion,
     },
-    Base64Decoded, Thunk,
+    Thunk,
 };
 use std::borrow::Cow;
 
@@ -21,9 +21,9 @@ const CREATOR_REGISTERED_DATA_TOO_MANY_FIELDS: &str = "4170784:Serponge:119741:3
 const TIME_PRESSURE: Level = Level {
     level_id: 897837,
     name: Cow::Borrowed("time pressure"),
-    description: Some(Thunk::Processed(Base64Decoded(Cow::Borrowed(
+    description: Some(Thunk::Processed(Cow::Borrowed(
         "please rate and like  8-9 stars mabye?",
-    )))),
+    ))),
     version: 2,
     creator: 842519,
     difficulty: LevelRating::Demon(DemonRating::Easy),

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -50,7 +50,7 @@ const TIME_PRESSURE: Level = Level {
     index_47: None,
     level_data: LevelData {
         level_data: Thunk::Unprocessed("REMOVED"),
-        password: Password::PasswordCopy(3101),
+        password: Thunk::Processed(Password::PasswordCopy(3101)),
         time_since_upload: Cow::Borrowed("5 years"),
         time_since_update: Cow::Borrowed("5 years"),
         index_36: None,
@@ -64,6 +64,8 @@ impl<S, U> helper::ThunkProcessor for Level<'_, LevelData<'_>, S, U> {
         }
         let objects = self.level_data.level_data.process();
         assert!(objects.is_ok(), "{:?}", objects.unwrap_err());
+        let pw = self.level_data.password.process();
+        assert!(pw.is_ok(), "{:?}", pw.unwrap_err());
     }
 }
 

--- a/tests/song.rs
+++ b/tests/song.rs
@@ -1,4 +1,4 @@
-use dash_rs::{model::song::NewgroundsSong, PercentDecoded, Thunk};
+use dash_rs::{model::song::NewgroundsSong, Thunk};
 use std::borrow::Cow;
 
 #[macro_use]
@@ -17,9 +17,9 @@ const CREO_DUNE: NewgroundsSong<'static> = NewgroundsSong {
     index_6: None,
     index_7: Some(Cow::Borrowed("UCsCWA3Y3JppL6feQiMRgm6Q")),
     index_8: Cow::Borrowed("1"),
-    link: Thunk::Processed(PercentDecoded(Cow::Borrowed(
+    link: Thunk::Processed(Cow::Borrowed(
         "https://audio.ngfiles.com/771000/771277_Creo---Dune.mp3?f1508708604",
-    ))),
+    )),
 };
 
 impl<'a> helper::ThunkProcessor for NewgroundsSong<'a> {


### PR DESCRIPTION
This PR removes the internal `RefThunk` abstraction (by making the observation that it is nonsensical for the internal representation to ever hold a reference to processed Thunk data), as well as changes the `Thunk::Unprocessed` variant to hold a `Cow<'src, str>` instead of a `&'src str` (this will allow fault-tolerant Thunk serialization: If the unprocessed thunk data is malformed, the end user might want to store the unprocessed data instead of aborting. However, it was impossible to deserialize a Thunk to its unprocessed state before, as it cannot hold owned, unprocessed data).