### PR TITLE
Add examples directory to show off dash-rs usage

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --examples --tests
   clippy:
     name: Clippy Lints
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ variant_partial_eq = { git = "https://github.com/stadust/variant-partial-eq" }
 env_logger = "0.7.1"
 criterion = "0.3"
 
+# Dependencies used by examples
+reqwest = "0.11.17"
+tokio = {version = "1.28.0", features = ["macros", "rt-multi-thread"]}
+
 [build-dependencies]
 serde = {version = "1.0.104", features = ["derive"]}
 serde_yaml = "0.8.14"

--- a/examples/download_featured_levels.rs
+++ b/examples/download_featured_levels.rs
@@ -1,0 +1,75 @@
+//! Retries the first page of featured levels, downloading the ones that can be copied in-game
+//!
+//! For each level that is free to copy, the server resposne is stored in `data/<level_id>.lvl`.
+//! For each level that requires a password to copy, the server resposne is stored in
+//! `data/<level_id>_<password>.lvl`.
+//!
+//! WARNING: Robtop has set some aggressive ratelimits on the download level endpoint. Attempting
+//! to download too many levels (20 per minute from my testing) in too short a period of time will ratelimit
+//! you for one hour (HTTP 429 with retry-after=3600). There is also a further ratelimit that last a full day,
+//! hit by downloading approximately 100 levels "too fast" (I am not sure on the details here). 
+//! Use this script at your own risk.
+
+use dash_rs::{
+    model::level::Password,
+    request::level::{LevelRequest, LevelRequestType, LevelsRequest},
+    response::{parse_download_gj_level_response, parse_get_gj_levels_response},
+};
+use reqwest::{
+    header::{HeaderMap, CONTENT_TYPE},
+    Client, Response,
+};
+use std::{time::Duration, path::Path};
+
+#[tokio::main]
+async fn main() {
+    let out_dir = Path::new("data");
+
+    if !out_dir.exists() {
+        std::fs::create_dir(out_dir).unwrap();
+    }
+
+    let http_client = Client::new();
+
+    // Note: There is a further ratelimit of 130 levels per ??, exceeding which will ban you for a day.
+    for page in 1.. {
+        let request = LevelsRequest::default().request_type(LevelRequestType::Featured).page(page);
+
+        let response = make_request(&http_client, &request.to_url(), request.to_string()).await;
+        let response_text = response.text().await.unwrap();
+
+        let levels = parse_get_gj_levels_response(&response_text).unwrap();
+
+        for level in levels {
+            println!("Downloading level {} (ID: {})", level.name, level.level_id);
+
+            let download_request = LevelRequest::new(level.level_id);
+
+            let response = make_request(&http_client, &download_request.to_url(), download_request.to_string()).await;
+
+            let response_text = response.text().await.unwrap();
+
+            let mut level = parse_download_gj_level_response(&response_text).unwrap();
+
+            match level.level_data.password.process() {
+                Ok(Password::FreeCopy) => std::fs::write(format!("../data/{}.lvl", level.level_id), &response_text).unwrap(),
+                Ok(Password::PasswordCopy(pw)) => std::fs::write(format!("../data/{}_{}.lvl", level.level_id, pw), &response_text).unwrap(),
+                _ => println!("Sadly not copyable, skipping!"),
+            }
+
+            // RobTop has a rate limit of 20 levels per minute. Exceeding it will results in a `429 TOO MANY
+            // REQUESTS` response with `retry-after: 3600`, effectively temp-banning you for an hour
+            std::thread::sleep(Duration::from_secs(60 / 20 + 1));
+        }
+    }
+}
+
+async fn make_request(client: &Client, endpoint: &str, data: String) -> Response {
+    client.post(endpoint)
+        .headers(HeaderMap::new())  // boomlings.com rejects any request with a User-Agent header set, so make sure reqwest doesn't "helpfully" add one
+        .body(data)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .send()
+        .await
+        .unwrap()
+}

--- a/src/serde/de/indexed.rs
+++ b/src/serde/de/indexed.rs
@@ -406,3 +406,33 @@ impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use crate::serde::IndexedDeserializer;
+    use serde::de::Deserialize;
+
+    const INPUT: &str = "1:hello:2:world";
+
+    #[test]
+    fn test_deserialize_map_like_to_hashmap() {
+        // Illustrates how to deserialize some arbitrary RobTop string into a HashMap, for easier analysis.
+        let mut deserializer = IndexedDeserializer::new(INPUT, ":", true);
+
+        let map = HashMap::<&str, &str>::deserialize(&mut deserializer).unwrap();
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("1"), Some(&"hello"));
+        assert_eq!(map.get("2"), Some(&"world"));
+    }
+
+    #[test]
+    fn test_deserialize_to_vec() {
+        let mut deserializer = IndexedDeserializer::new(INPUT, ":", false);
+
+        let vec = Vec::<&str>::deserialize(&mut deserializer).unwrap();
+
+        assert_eq!(vec, INPUT.split(':').collect::<Vec<_>>())
+    }
+}


### PR DESCRIPTION
The example is a short script that start downloading (and locally storing) featured level if they are in-game copyable.