### PR TITLE
add support for other GD related servers (including GDPSes)

### DIFF
--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -44,7 +44,13 @@ pub mod comment;
 pub mod level;
 pub mod user;
 
-pub const REQUEST_BASE_URL: &str = "https://www.boomlings.com/database/";
+pub fn get_gdps_url() -> String {
+    println!("ok1");
+    println!("{}",std::env::var("GDPS_URL").unwrap_or("https://www.boomlings.com/database/".to_string()).to_string());
+    std::env::var("GDPS_URL").unwrap_or("https://www.boomlings.com/database/".to_string())
+}
+
+//pub const REQUEST_BASE_URL: &str = "https://www.boomlings.com/database/";
 
 /// A `BaseRequest` instance that has all its fields set to the
 /// same values a Geometry Dash 2.1 client would use
@@ -99,7 +105,7 @@ pub struct BaseRequest<'a> {
 
 impl BaseRequest<'_> {
     /// Constructs a new `BaseRequest` with the given values.
-    pub const fn new(game_version: GameVersion, binary_version: GameVersion, secret: &'static str) -> BaseRequest<'_> {
+    pub const fn new(game_version: GameVersion, binary_version: GameVersion, secret: &'static str) -> BaseRequest<'static> {
         BaseRequest {
             game_version,
             binary_version,


### PR DESCRIPTION
this commit adds GDPS_URL to dash-rs, which makes it easier to manage a Pointercrate instance that is used for something other than the main Geometry Dash servers (e.g 1.9 GDPS). If there is anything wrong with this commit, comment on it. Thanks :P

- LG125 & yuptune